### PR TITLE
[JENKINS-61295] Catch IllegalArgumentException when creating relative paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <module.name>${project.groupId}.plugin.util.api</module.name>
 
     <commons.lang.version>3.9</commons.lang.version>
-    <codingstyle.library.version>1.0.1</codingstyle.library.version>
+    <codingstyle.library.version>1.0.2</codingstyle.library.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
On Windows an IAE is thrown if the relative path cannot be created.
See https://issues.jenkins-ci.org/browse/JENKINS-61295.
Followup to upstream https://github.com/uhafner/codingstyle/commit/dda89ba54f5164ccb68b09a6cb62de4ce78e8e81