### PR TITLE
Fix path to ball color icons

### DIFF
--- a/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
@@ -123,7 +123,7 @@ public class JenkinsFacade implements Serializable {
      * @return the absolute URL
      */
     public String getImagePath(final BallColor color) {
-        return getContextPath() + "/images/16x16/" + color;
+        return getContextPath() + "/images/16x16/" + color.getImage();
     }
 
     /**


### PR DESCRIPTION
Add the missing `.gif` extension to the file name.