### PR TITLE
Remove redundant slash in absolute url

### DIFF
--- a/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
@@ -163,7 +163,7 @@ public class JenkinsFacade implements Serializable {
         try {
             String rootUrl = getJenkins().getRootUrl();
             if (rootUrl != null) {
-                return rootUrl + "/" + url;
+                return rootUrl + url;
             }
         }
         catch (IllegalStateException ignored) {


### PR DESCRIPTION
When constructing absolute URL in `JenkinFacade`, a redundant slash is added:

https://github.com/jenkinsci/plugin-util-api-plugin/blob/933fad9658697c9c59cbb2bc26f473214dc1aafc/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java#L164-L167

`getRootUrl` will alwasy have a trailing slash, see JavaDoc: https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getRootUrl--
