### PR TITLE
Bump version of analysis pom to 5.0.0-

### DIFF
--- a/etc/spotbugs-inclusion-filter.xml
+++ b/etc/spotbugs-inclusion-filter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ${project.groupId}:${project.artifactId}:${project.version} -->
+<FindBugsFilter>
+  <Match>
+      <Package name="io.jenkins.plugins.util" />
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,13 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration combine.children="append">
+          <includeFilterFile>etc/spotbugs-inclusion-filter.xml</includeFilterFile>
+        </configuration>
+      </plugin>
       <!-- Unpack and copy classes of codingstyle so that these classes are part of this plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>4.7.0</version>
+    <version>5.0.0-beta-1</version>
     <relativePath />
   </parent>
 
@@ -18,13 +18,15 @@
   <url>https://github.com/jenkinsci/plugin-util-api-plugin</url>
 
   <properties>
-    <revision>1.8.0</revision>
+    <revision>2.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.plugin.util.api</module.name>
 
-    <commons.lang.version>3.11</commons.lang.version>
-    <codingstyle.library.version>1.6.0</codingstyle.library.version>
+    <codingstyle.library.version>2.0.5</codingstyle.library.version>
+    <error-prone.version>2.5.1</error-prone.version>
+    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+
   </properties>
 
   <licenses>
@@ -48,13 +50,12 @@
       <groupId>edu.hm.hafner</groupId>
       <artifactId>codingstyle</artifactId>
       <version>${codingstyle.library.version}</version>
+      <scope>provided</scope>
       <exclusions>
-        <!-- Remove once on at least 2.249 baseline -->
         <exclusion>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-annotations</artifactId>
         </exclusion>
-        <!-- Remove once on at least the baseline after 2.249 -->
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
@@ -62,9 +63,16 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang.version}</version>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>${error-prone.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>${javax.annotation-api.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test Plugin Dependencies -->
@@ -90,12 +98,10 @@
       <scope>test</scope>
       <type>test-jar</type>
       <exclusions>
-        <!-- Remove once on at least 2.249 baseline -->
         <exclusion>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-annotations</artifactId>
         </exclusion>
-        <!-- Remove once on at least the baseline after 2.249 -->
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
@@ -120,7 +126,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
-              <includeArtifactIds>codingstyle</includeArtifactIds>
+              <includeArtifactIds>codingstyle,error_prone_annotations,javax.annotation-api</includeArtifactIds>
               <excludeTypes>test-jar</excludeTypes>
               <excludes>META-INF/**/*</excludes>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.0.0-beta-1</version>
+    <version>5.0.0-beta-2</version>
     <relativePath />
   </parent>
 
@@ -23,7 +23,7 @@
 
     <module.name>${project.groupId}.plugin.util.api</module.name>
 
-    <codingstyle.library.version>2.0.5</codingstyle.library.version>
+    <codingstyle.library.version>2.0.6</codingstyle.library.version>
     <error-prone.version>2.5.1</error-prone.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <commons.lang.version>3.11</commons.lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.0.0-beta-2</version>
+    <version>5.0.0</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <codingstyle.library.version>2.0.5</codingstyle.library.version>
     <error-prone.version>2.5.1</error-prone.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+    <commons.lang.version>3.11</commons.lang.version>
 
   </properties>
 
@@ -72,6 +73,12 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>${javax.annotation-api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -126,7 +133,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
-              <includeArtifactIds>codingstyle,error_prone_annotations,javax.annotation-api</includeArtifactIds>
+              <includeArtifactIds>codingstyle,error_prone_annotations,javax.annotation-api,commons-lang3</includeArtifactIds>
               <excludeTypes>test-jar</excludeTypes>
               <excludes>META-INF/**/*</excludes>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <error-prone.version>2.5.1</error-prone.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <commons.lang.version>3.11</commons.lang.version>
+    <commons-text.version>1.9</commons-text.version>
 
   </properties>
 
@@ -81,7 +82,12 @@
       <version>${commons.lang.version}</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test Plugin Dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -140,7 +146,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
-              <includeArtifactIds>codingstyle,error_prone_annotations,javax.annotation-api,commons-lang3</includeArtifactIds>
+              <includeArtifactIds>codingstyle,error_prone_annotations,javax.annotation-api,commons-lang3,commons-text</includeArtifactIds>
               <excludeTypes>test-jar</excludeTypes>
               <excludes>META-INF/**/*</excludes>
             </configuration>


### PR DESCRIPTION
- Requires new Jenkins Baseline 2.249.1
- Embed all required libraries into plugin-util bundle.
- Remove all dependencies that are already part of Jenkins core.