### PR TITLE
Mark usage of `BallColor` as deprecated

### DIFF
--- a/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
@@ -207,7 +207,10 @@ public class JenkinsFacade implements Serializable {
      *         the color
      *
      * @return the absolute URL
+     * @deprecated BallColor should not be used anymore, use the {@code icon} tag in jelly views or the icon class name
+     *         of {@link BallColor}
      */
+    @Deprecated
     public String getImagePath(final BallColor color) {
         return getContextPath() + "/images/16x16/" + color.getImage();
     }


### PR DESCRIPTION
Jenkins status icons have been changed recently. However, the Jenkins core class `BallColor` has not been adapted yet. So it makes sense to obtain the correct icons in a different way. 