### PR TITLE
Add a class to navigate to results of another build

### DIFF
--- a/src/main/java/io/jenkins/plugins/util/BuildResultNavigator.java
+++ b/src/main/java/io/jenkins/plugins/util/BuildResultNavigator.java
@@ -9,7 +9,6 @@ import hudson.model.Run;
  *
  * @author Ullrich Hafner
  */
-// FIXME: move to plugin-util or echarts
 public class BuildResultNavigator {
     private static final String SLASH = "/";
 

--- a/src/main/java/io/jenkins/plugins/util/BuildResultNavigator.java
+++ b/src/main/java/io/jenkins/plugins/util/BuildResultNavigator.java
@@ -1,0 +1,63 @@
+package io.jenkins.plugins.util;
+
+import java.util.Optional;
+
+import hudson.model.Run;
+
+/**
+ * Navigates from the current results to the same results of any other build of the same job.
+ *
+ * @author Ullrich Hafner
+ */
+// FIXME: move to plugin-util or echarts
+public class BuildResultNavigator {
+    private static final String SLASH = "/";
+
+    /**
+     * Navigates from the current results to the same results of any other build of the same job.
+     *
+     * @param currentBuild
+     *         the current build that owns the view results
+     * @param currentAbsoluteBrowserUrl
+     *         the absolute URL to the view results
+     * @param resultId
+     *         the ID of the static analysis results
+     * @param selectedBuildDisplayName
+     *         the selected build to open the new results for
+     *
+     * @return the URL to the results if possible
+     */
+    public Optional<String> getSameUrlForOtherBuild(final Run<?, ?> currentBuild, final String currentAbsoluteBrowserUrl,
+            final String resultId, final String selectedBuildDisplayName) {
+        for (Run<?, ?> run = currentBuild.getParent().getLastBuild(); run != null; run = run.getPreviousBuild()) {
+            if (selectedBuildDisplayName.equals(run.getDisplayName())) {
+                return getSameUrlForOtherBuild(currentBuild, currentAbsoluteBrowserUrl, resultId, run);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Navigates from the current results to the same results of any other build of the same job.
+     *
+     * @param currentBuild
+     *         the current build that owns the view results
+     * @param viewUrl
+     *         the absolute URL to the view results
+     * @param resultId
+     *         the ID of the static analysis results
+     * @param selectedBuild
+     *         the selected build to open the new results for
+     *
+     * @return the URL to the results if possible
+     */
+    public Optional<String> getSameUrlForOtherBuild(final Run<?, ?> currentBuild, final String viewUrl,
+            final String resultId, final Run<?, ?> selectedBuild) {
+        String match = SLASH + currentBuild.getNumber() + SLASH + resultId;
+        if (viewUrl.contains(match)) {
+            return Optional.of(viewUrl.replaceFirst(
+                    match + ".*", SLASH + selectedBuild.getNumber() + SLASH + resultId));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/util/BuildResultNavigatorTest.java
+++ b/src/test/java/io/jenkins/plugins/util/BuildResultNavigatorTest.java
@@ -1,0 +1,112 @@
+package io.jenkins.plugins.util;
+
+import org.junit.jupiter.api.Test;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link BuildResultNavigator}.
+ *
+ * @author Ullrich Hafner
+ */
+class BuildResultNavigatorTest {
+    @Test
+    void shouldNavigateToSelectedBuild() {
+        BuildResultNavigator navigator = new BuildResultNavigator();
+
+        FreeStyleBuild current = mock(FreeStyleBuild.class);
+        FreeStyleProject job = mock(FreeStyleProject.class);
+        when(current.getParent()).thenReturn(job);
+        when(current.getNumber()).thenReturn(100);
+
+        FreeStyleBuild lastBuild = mock(FreeStyleBuild.class);
+        when(job.getLastBuild()).thenReturn(lastBuild);
+        when(lastBuild.getDisplayName()).thenReturn("last-build");
+        when(lastBuild.getNumber()).thenReturn(111);
+
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/100/spotbugs/",
+                "spotbugs",
+                "last-build"))
+                .isNotEmpty()
+                .contains("http://localhost:8080/job/pipeline-analysis-model/111/spotbugs");
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/different-url",
+                "spotbugs",
+                "last-build"))
+                .isEmpty();
+
+    }
+
+    @Test
+    void shouldNavigateToSameBuild() {
+        BuildResultNavigator navigator = new BuildResultNavigator();
+
+        FreeStyleBuild current = mock(FreeStyleBuild.class);
+        FreeStyleProject job = mock(FreeStyleProject.class);
+        when(current.getParent()).thenReturn(job);
+        when(current.getNumber()).thenReturn(100);
+        when(current.getDisplayName()).thenReturn("#100");
+
+        FreeStyleBuild lastBuild = mock(FreeStyleBuild.class);
+        when(job.getLastBuild()).thenReturn(lastBuild);
+        when(lastBuild.getDisplayName()).thenReturn("#111");
+        when(lastBuild.getNumber()).thenReturn(111);
+        when(lastBuild.getPreviousBuild()).thenReturn(current);
+
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/100/spotbugs/",
+                "spotbugs",
+                "#100"))
+                .isNotEmpty()
+                .contains("http://localhost:8080/job/pipeline-analysis-model/100/spotbugs");
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/100/spotbugs/",
+                "spotbugs",
+                "#111"))
+                .isNotEmpty()
+                .contains("http://localhost:8080/job/pipeline-analysis-model/111/spotbugs");
+    }
+
+    @Test
+    void shouldNotFindBuildForUrl() {
+        BuildResultNavigator navigator = new BuildResultNavigator();
+
+        FreeStyleBuild current = mock(FreeStyleBuild.class);
+        FreeStyleProject job = mock(FreeStyleProject.class);
+        when(current.getParent()).thenReturn(job);
+        when(current.getNumber()).thenReturn(100);
+
+        FreeStyleBuild lastBuild = mock(FreeStyleBuild.class);
+        when(job.getLastBuild()).thenReturn(lastBuild);
+        when(lastBuild.getDisplayName()).thenReturn("last-build");
+        when(lastBuild.getNumber()).thenReturn(111);
+
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/100/spotbugs/",
+                "spotbugs",
+                "wrong-selection"))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldNotFindBuildIfThereIsNoLastBuild() {
+        BuildResultNavigator navigator = new BuildResultNavigator();
+
+        FreeStyleBuild current = mock(FreeStyleBuild.class);
+        FreeStyleProject job = mock(FreeStyleProject.class);
+        when(current.getParent()).thenReturn(job);
+        when(current.getNumber()).thenReturn(100);
+
+        assertThat(navigator.getSameUrlForOtherBuild(current,
+                "http://localhost:8080/job/pipeline-analysis-model/100/spotbugs/",
+                "spotbugs",
+                "wrong-selection"))
+                .isEmpty();
+    }
+
+}


### PR DESCRIPTION
A utility class that helps to navigate from the trend chart in the current build to the build results of a selected build without storing the actual URLs. The target URL is composed by replacing the current build number with the selected build number.