### PR TITLE
Fix broken side panel link on the job level

### DIFF
--- a/src/main/java/io/jenkins/plugins/util/JobAction.java
+++ b/src/main/java/io/jenkins/plugins/util/JobAction.java
@@ -64,8 +64,9 @@ public abstract class JobAction<T extends BuildAction<?>> implements Action {
         Optional<T> action = getLatestAction();
         if (action.isPresent()) {
             T buildAction = action.get();
-            response.sendRedirect2(String.format("../../../%s%s",
-                    buildAction.getOwner().getUrl(), buildAction.getUrlName()));
+            response.sendRedirect2(String.format("../%d/%s",
+                    buildAction.getOwner().getNumber(),
+                    buildAction.getUrlName()));
         }
     }
 


### PR DESCRIPTION
Now simply use the URL `../[build]/[url]` to navigate to the latest results.

Fixes:
- https://github.com/jenkinsci/code-coverage-api-plugin/issues/227
- https://github.com/jenkinsci/code-coverage-api-plugin/issues/231

