### PR TITLE
Avoid Enforcer errors in dependent plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
       <scope>test</scope>
       <type>test-jar</type>
       <exclusions>
+        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-annotations</artifactId>
@@ -118,6 +119,10 @@
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Similar to #147. Avoids these Enforcer errors in downstream plugins:

```
Require upper bound dependencies error for javax.annotation:javax.annotation-api:1.2 [provided] paths to dependency are:
+-org.jenkins-ci.plugins:github-oauth:0.37-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.289.1 [provided]
    +-org.kohsuke.stapler:stapler:1.263 [provided] (managed) <-- org.kohsuke.stapler:stapler:1.263 [provided]
      +-javax.annotation:javax.annotation-api:1.2 [provided]
and
+-org.jenkins-ci.plugins:github-oauth:0.37-SNAPSHOT
  +-org.jenkins-ci.plugins:matrix-project:1.19
    +-org.jenkins-ci.plugins:junit:1.53 (managed) <-- org.jenkins-ci.plugins:junit:1.47
      +-io.jenkins.plugins:plugin-util-api:2.9.0 (managed) <-- io.jenkins.plugins:plugin-util-api:2.4.0
        +-edu.hm.hafner:codingstyle:2.14.0 [provided]
          +-javax.annotation:javax.annotation-api:1.3.2 [provided]
```