### PR TITLE
Avoid Enforcer errors in dependent plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Similar to #150. Avoids these Enforcer errors in downstream plugins:

```
Require upper bound dependencies error for javax.annotation:javax.annotation-api:1.2 [provided] paths to dependency are:
+-org.jenkins-ci.plugins:nodelabelparameter:1.10.4-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.289.1 [provided]
    +-org.kohsuke.stapler:stapler:1.263 [provided] (managed) <-- org.kohsuke.stapler:stapler:1.263 [provided]
      +-javax.annotation:javax.annotation-api:1.2 [provided]
and
+-org.jenkins-ci.plugins:nodelabelparameter:1.10.4-SNAPSHOT
  +-org.jenkins-ci.plugins:parameterized-trigger:2.36
    +-org.jenkins-ci.plugins:matrix-project:1.19 (managed) <-- org.jenkins-ci.plugins:matrix-project:1.6
      +-org.jenkins-ci.plugins:junit:1.53 (managed) <-- org.jenkins-ci.plugins:junit:1.47
        +-io.jenkins.plugins:plugin-util-api:2.11.0 (managed) <-- io.jenkins.plugins:plugin-util-api:2.4.0
          +-edu.hm.hafner:codingstyle:2.14.0 [provided]
            +-javax.annotation:javax.annotation-api:1.3.2 [provided]
```