### PR TITLE
Add helpers to create Docker agents in integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <commons.lang.version>3.12.0</commons.lang.version>
     <commons-text.version>1.9</commons-text.version>
     <j2html.version>1.4.0</j2html.version>
+    <docker-fixtures.version>1.11</docker-fixtures.version>
 
   </properties>
 
@@ -47,7 +48,6 @@
   </developers>
 
   <dependencies>
-
     <dependency>
       <groupId>edu.hm.hafner</groupId>
       <artifactId>codingstyle</artifactId>
@@ -129,6 +129,18 @@
           <artifactId>javax.annotation-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Docker Agents -->
+    <dependency>
+      <groupId>org.jenkins-ci.test</groupId>
+      <artifactId>docker-fixtures</artifactId>
+      <version>${docker-fixtures.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/src/test/java/io/jenkins/plugins/util/JavaGitContainer.java
+++ b/src/test/java/io/jenkins/plugins/util/JavaGitContainer.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.util;
+
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
+
+/**
+ * Represents a server with SSHD, Java tooling, Maven and Git.
+ *
+ * @author Ullrich Hafner
+ */
+@DockerFixture(id = "java-git", ports = {22, 8080})
+public class JavaGitContainer extends SshdContainer {
+    /**
+     * Creates a new instance of {@link JavaGitContainer}.
+     */
+    @SuppressWarnings("PMD.UnnecessaryConstructor")
+    public JavaGitContainer() {
+        super();
+
+        // required for dependency injection
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/util/JavaGitContainer/Dockerfile
+++ b/src/test/resources/io/jenkins/plugins/util/JavaGitContainer/Dockerfile
@@ -1,0 +1,16 @@
+#
+# Container for running Java processes
+#
+
+# sha1sum ../SshdContainer/Dockerfile | cut -c 1-12
+FROM jenkins/sshd:32edfdd58111
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        software-properties-common \
+        openjdk-8-jre-headless \
+        openjdk-8-jdk-headless \
+        curl \
+        ant \
+        maven \
+        git


### PR DESCRIPTION
Adds a `JavaGitContainer` that can be used as an agent in integration tests. 