### PR TITLE
replace usages of commons.lang3 and commons.text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
   <url>https://github.com/jenkinsci/plugin-util-api-plugin</url>
 
   <properties>
+    <jenkins.baseline>2.361</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.2</jenkins.version>
     <revision>2.19.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
@@ -160,7 +162,11 @@
       <artifactId>ssh-slaves</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-lang3-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-text-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>edu.hm.hafner</groupId>
       <artifactId>codingstyle</artifactId>
       <version>${codingstyle.library.version}</version>

--- a/src/main/java/io/jenkins/plugins/util/EnvironmentResolver.java
+++ b/src/main/java/io/jenkins/plugins/util/EnvironmentResolver.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.util;
 
-import org.apache.commons.lang3.StringUtils;
-
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
+import org.springframework.util.StringUtils;
 import hudson.EnvVars;
 import hudson.Util;
 
@@ -45,7 +43,7 @@ public class EnvironmentResolver {
     public String expandEnvironmentVariables(@CheckForNull final EnvVars environment, final String nonExpandedValue) {
         String expanded = nonExpandedValue;
         if (environment != null && !environment.isEmpty()) {
-            for (int i = 0; i < resolveVariablesDepth && StringUtils.isNotBlank(expanded); i++) {
+            for (int i = 0; i < resolveVariablesDepth && StringUtils.hasText(expanded) && StringUtils.hasLength(expanded); i++) {
                 String old = expanded;
                 expanded = Util.replaceMacro(expanded, environment);
                 if (old.equals(expanded)) {

--- a/src/main/java/io/jenkins/plugins/util/EnvironmentResolver.java
+++ b/src/main/java/io/jenkins/plugins/util/EnvironmentResolver.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.util;
 
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import org.springframework.util.StringUtils;
 import hudson.EnvVars;
 import hudson.Util;
 
@@ -43,7 +42,7 @@ public class EnvironmentResolver {
     public String expandEnvironmentVariables(@CheckForNull final EnvVars environment, final String nonExpandedValue) {
         String expanded = nonExpandedValue;
         if (environment != null && !environment.isEmpty()) {
-            for (int i = 0; i < resolveVariablesDepth && StringUtils.hasText(expanded) && StringUtils.hasLength(expanded); i++) {
+            for (int i = 0; i < resolveVariablesDepth && !expanded.isBlank(); i++) {
                 String old = expanded;
                 expanded = Util.replaceMacro(expanded, environment);
                 if (old.equals(expanded)) {

--- a/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.security.access.AccessDeniedException;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -257,7 +257,7 @@ public class JenkinsFacade implements Serializable {
         if (currentRequest != null) {
             return currentRequest.getContextPath();
         }
-        return StringUtils.EMPTY;
+        return "";
     }
 
     /**
@@ -269,7 +269,7 @@ public class JenkinsFacade implements Serializable {
      * @return the absolute URL
      */
     public String getAbsoluteUrl(final String... urlElements) {
-        return getAbsoluteUrl(StringUtils.join(urlElements, "/"));
+        return getAbsoluteUrl(StringUtils.arrayToDelimitedString(urlElements, "/"));
 
     }
 

--- a/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/util/JenkinsFacade.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.util.StringUtils;
 import org.springframework.security.access.AccessDeniedException;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -269,7 +268,7 @@ public class JenkinsFacade implements Serializable {
      * @return the absolute URL
      */
     public String getAbsoluteUrl(final String... urlElements) {
-        return getAbsoluteUrl(StringUtils.arrayToDelimitedString(urlElements, "/"));
+        return getAbsoluteUrl(String.join("/", urlElements));
 
     }
 

--- a/src/test/java/io/jenkins/plugins/util/FormValidationAssert.java
+++ b/src/test/java/io/jenkins/plugins/util/FormValidationAssert.java
@@ -2,11 +2,12 @@ package io.jenkins.plugins.util;
 
 import java.util.Objects;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.assertj.core.api.AbstractAssert;
 
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
-import org.springframework.web.util.HtmlUtils;
+
 
 /**
  * Assertions for {@link FormValidation} instances.
@@ -87,10 +88,10 @@ public class FormValidationAssert extends AbstractAssert<FormValidationAssert, F
     public FormValidationAssert hasMessage(final String expectedMessage) {
         isNotNull();
 
-        String actualMessage = HtmlUtils.htmlUnescape(actual.getMessage());
+        String actualMessage = StringEscapeUtils.unescapeHtml4(actual.getMessage());
         if (!Objects.equals(actualMessage, expectedMessage)) {
             failWithMessage(EXPECTED_BUT_WAS_MESSAGE, "message",
-                    HtmlUtils.htmlUnescape(actual.toString()), expectedMessage, actualMessage);
+                    StringEscapeUtils.unescapeHtml4(actual.toString()), expectedMessage, actualMessage);
         }
 
         return this;
@@ -109,10 +110,10 @@ public class FormValidationAssert extends AbstractAssert<FormValidationAssert, F
     public FormValidationAssert hasMessageContaining(final String expectedMessagePart) {
         isNotNull();
 
-        String actualMessage = HtmlUtils.htmlUnescape(actual.getMessage());
+        String actualMessage = StringEscapeUtils.unescapeHtml4(actual.getMessage());
         if (!actualMessage.contains(expectedMessagePart)) {
             failWithMessage("%nExpecting %s of:%n <%s>%nto contain:%n <%s>%nbut was:%n <%s>.", "message",
-                    HtmlUtils.htmlUnescape(actual.toString()), expectedMessagePart, actualMessage);
+                    StringEscapeUtils.unescapeHtml4(actual.toString()), expectedMessagePart, actualMessage);
         }
 
         return this;

--- a/src/test/java/io/jenkins/plugins/util/FormValidationAssert.java
+++ b/src/test/java/io/jenkins/plugins/util/FormValidationAssert.java
@@ -2,12 +2,11 @@ package io.jenkins.plugins.util;
 
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.assertj.core.api.AbstractAssert;
 
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
+import org.springframework.web.util.HtmlUtils;
 
 /**
  * Assertions for {@link FormValidation} instances.
@@ -88,10 +87,10 @@ public class FormValidationAssert extends AbstractAssert<FormValidationAssert, F
     public FormValidationAssert hasMessage(final String expectedMessage) {
         isNotNull();
 
-        String actualMessage = StringEscapeUtils.unescapeHtml4(actual.getMessage());
+        String actualMessage = HtmlUtils.htmlUnescape(actual.getMessage());
         if (!Objects.equals(actualMessage, expectedMessage)) {
             failWithMessage(EXPECTED_BUT_WAS_MESSAGE, "message",
-                    StringEscapeUtils.unescapeHtml4(actual.toString()), expectedMessage, actualMessage);
+                    HtmlUtils.htmlUnescape(actual.toString()), expectedMessage, actualMessage);
         }
 
         return this;
@@ -110,10 +109,10 @@ public class FormValidationAssert extends AbstractAssert<FormValidationAssert, F
     public FormValidationAssert hasMessageContaining(final String expectedMessagePart) {
         isNotNull();
 
-        String actualMessage = StringEscapeUtils.unescapeHtml4(actual.getMessage());
-        if (!StringUtils.contains(actualMessage, expectedMessagePart)) {
+        String actualMessage = HtmlUtils.htmlUnescape(actual.getMessage());
+        if (!actualMessage.contains(expectedMessagePart)) {
             failWithMessage("%nExpecting %s of:%n <%s>%nto contain:%n <%s>%nbut was:%n <%s>.", "message",
-                    StringEscapeUtils.unescapeHtml4(actual.toString()), expectedMessagePart, actualMessage);
+                    HtmlUtils.htmlUnescape(actual.toString()), expectedMessagePart, actualMessage);
         }
 
         return this;


### PR DESCRIPTION

Removing dependency of commons-lang3 and replacing with standard JDK11 methods. Keeping the commons-text dependency only for test scope. Also, I override the jenkins baseline in order to be able to use Java11 methods

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
