### PR TITLE
Remove duplicate dependency to commons-lang and commons-text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-lang3-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-text-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>edu.hm.hafner</groupId>
       <artifactId>codingstyle</artifactId>
       <version>${codingstyle.library.version}</version>


### PR DESCRIPTION
Remove direct dependency as this dependency is already pulled in from the parent pom:
see https://github.com/jenkinsci/analysis-pom-plugin/pull/598
