### PR TITLE
Revert "Bump dependency com.j2html:j2html to v1.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <module.name>${project.groupId}.plugin.util.api</module.name>
 
     <error-prone.version>2.36.0</error-prone.version>
-    <j2html.version>1.6.0</j2html.version>
+    <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.8.4</streamex.version>
     <testcontainers.version>2.0.4</testcontainers.version>
     <codingstyle.library.version>6.6.0</codingstyle.library.version>


### PR DESCRIPTION
This reverts commit c059f2a98ea4db499f87c786b4c20a2a13fb5846.

We need to stay at v1.4.0 as the newer versions are not backward compatible.