### PR TITLE
Remove obsolete incremental Maven configuration

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
 -Dchangelist.format=%d.v%s
--Pconsume-incrementals
 -Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -187,24 +187,6 @@
 
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-    <repository>
-      <id>incrementals.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/warnings-ng-plugin/pull/3382